### PR TITLE
refactor: Entity-Dto 분리 및 Mapper 추가, PriceAlertService 단위 테스트 성공

### DIFF
--- a/apps/api-server/src/main/java/com/skytracker/entity/FlightAlert.java
+++ b/apps/api-server/src/main/java/com/skytracker/entity/FlightAlert.java
@@ -1,6 +1,5 @@
 package com.skytracker.entity;
 
-import com.skytracker.common.dto.alerts.FlightAlertRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,39 +65,6 @@ public class FlightAlert extends BaseTimeEntity{
     public void updateNewPrice(int newPrice){
         this.lastCheckedPrice = this.newPrice;
         this.newPrice = newPrice;
-    }
-
-    public static FlightAlert from(FlightAlertRequestDto dto){
-        return FlightAlert.builder()
-                .airlineCode(dto.getAirlineCode())
-                .flightNumber(dto.getFlightNumber())
-                .departureAirport(dto.getDepartureAirport())
-                .arrivalAirport(dto.getArrivalAirport())
-                .departureDate(dto.getDepartureDate())
-                .travelClass(dto.getTravelClass())
-                .currency(dto.getCurrency())
-                .adults(dto.getAdults())
-                .lastCheckedPrice(dto.getLastCheckedPrice())
-                .build();
-    }
-
-    /**
-     * FlightAlert → FlightAlertRequestDto 변환
-     */
-    public static FlightAlertRequestDto from(FlightAlert flightAlert) {
-        return FlightAlertRequestDto.builder()
-                .flightId(flightAlert.getId())
-                .airlineCode(flightAlert.getAirlineCode())
-                .flightNumber(flightAlert.getFlightNumber())
-                .departureAirport(flightAlert.getDepartureAirport())
-                .arrivalAirport(flightAlert.getArrivalAirport())
-                .departureDate(flightAlert.getDepartureDate())
-                .travelClass(flightAlert.getTravelClass())
-                .currency(flightAlert.getCurrency())
-                .adults(flightAlert.getAdults())
-                .lastCheckedPrice(flightAlert.getLastCheckedPrice())
-                .newPrice(flightAlert.getNewPrice())
-                .build();
     }
 
 }

--- a/apps/api-server/src/main/java/com/skytracker/entity/User.java
+++ b/apps/api-server/src/main/java/com/skytracker/entity/User.java
@@ -1,6 +1,6 @@
 package com.skytracker.entity;
 
-import com.skytracker.dto.enums.Role;
+import com.skytracker.dto.user.Role;
 import com.skytracker.dto.user.SocialUserRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/apps/api-server/src/main/java/com/skytracker/entity/UserFlightAlert.java
+++ b/apps/api-server/src/main/java/com/skytracker/entity/UserFlightAlert.java
@@ -1,6 +1,5 @@
 package com.skytracker.entity;
 
-import com.skytracker.common.dto.alerts.FlightAlertResponseDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,24 +30,6 @@ public class UserFlightAlert extends BaseTimeEntity{
 
     public void setActive(boolean active) {
         this.isActive = active;
-    }
-
-    public static FlightAlertResponseDto from(UserFlightAlert userFlightAlert) {
-        FlightAlert alert = userFlightAlert.getFlightAlert();
-        return FlightAlertResponseDto.builder()
-                .alertId(userFlightAlert.getId())
-                .origin(alert.getDepartureAirport())
-                .destination(alert.getArrivalAirport())
-                .departureDate(alert.getDepartureDate())
-                .returnDate(alert.getArrivalDate())
-                .airlineCode(alert.getAirlineCode())
-                .flightNumber(alert.getFlightNumber())
-                .travelClass(alert.getTravelClass())
-                .currency(alert.getCurrency())
-                .targetPrice(alert.getTargetPrice())
-                .lastCheckedPrice(alert.getLastCheckedPrice())
-                .isActive(userFlightAlert.isActive())
-                .build();
     }
 
 }

--- a/apps/api-server/src/main/java/com/skytracker/mapper/FlightAlertMapper.java
+++ b/apps/api-server/src/main/java/com/skytracker/mapper/FlightAlertMapper.java
@@ -1,0 +1,45 @@
+package com.skytracker.mapper;
+
+import com.skytracker.common.dto.alerts.FlightAlertRequestDto;
+import com.skytracker.entity.FlightAlert;
+
+public class FlightAlertMapper {
+
+
+    /**
+     * FlightAlertRequestDto → FlightAlert 변환
+     */
+    public static FlightAlert toEntity(FlightAlertRequestDto dto){
+        return FlightAlert.builder()
+                .airlineCode(dto.getAirlineCode())
+                .flightNumber(dto.getFlightNumber())
+                .departureAirport(dto.getDepartureAirport())
+                .arrivalAirport(dto.getArrivalAirport())
+                .departureDate(dto.getDepartureDate())
+                .travelClass(dto.getTravelClass())
+                .currency(dto.getCurrency())
+                .adults(dto.getAdults())
+                .lastCheckedPrice(dto.getLastCheckedPrice())
+                .build();
+    }
+
+    /**
+     * FlightAlert → FlightAlertRequestDto 변환
+     */
+    public static FlightAlertRequestDto from(FlightAlert flightAlert) {
+        return FlightAlertRequestDto.builder()
+                .flightId(flightAlert.getId())
+                .airlineCode(flightAlert.getAirlineCode())
+                .flightNumber(flightAlert.getFlightNumber())
+                .departureAirport(flightAlert.getDepartureAirport())
+                .arrivalAirport(flightAlert.getArrivalAirport())
+                .departureDate(flightAlert.getDepartureDate())
+                .travelClass(flightAlert.getTravelClass())
+                .currency(flightAlert.getCurrency())
+                .adults(flightAlert.getAdults())
+                .lastCheckedPrice(flightAlert.getLastCheckedPrice())
+                .newPrice(flightAlert.getNewPrice())
+                .build();
+    }
+
+}

--- a/apps/api-server/src/main/java/com/skytracker/mapper/UserFlightAlertMapper.java
+++ b/apps/api-server/src/main/java/com/skytracker/mapper/UserFlightAlertMapper.java
@@ -1,0 +1,26 @@
+package com.skytracker.mapper;
+
+import com.skytracker.common.dto.alerts.FlightAlertResponseDto;
+import com.skytracker.entity.FlightAlert;
+import com.skytracker.entity.UserFlightAlert;
+
+public class UserFlightAlertMapper {
+
+    public static FlightAlertResponseDto toDto(UserFlightAlert userFlightAlert) {
+        FlightAlert alert = userFlightAlert.getFlightAlert();
+
+        return FlightAlertResponseDto.builder()
+                .alertId(userFlightAlert.getId())
+                .origin(alert.getDepartureAirport())
+                .destination(alert.getArrivalAirport())
+                .flightNumber(alert.getFlightNumber())
+                .departureDate(alert.getDepartureDate())
+                .travelClass(alert.getTravelClass())
+                .airlineCode(alert.getAirlineCode())
+                .lastCheckedPrice(alert.getLastCheckedPrice())
+                .returnDate(alert.getArrivalDate())
+                .currency(alert.getCurrency())
+                .isActive(userFlightAlert.isActive())
+                .build();
+    }
+}

--- a/apps/api-server/src/main/java/com/skytracker/service/PriceAlertService.java
+++ b/apps/api-server/src/main/java/com/skytracker/service/PriceAlertService.java
@@ -5,6 +5,8 @@ import com.skytracker.common.dto.alerts.FlightAlertResponseDto;
 import com.skytracker.entity.FlightAlert;
 import com.skytracker.entity.User;
 import com.skytracker.entity.UserFlightAlert;
+import com.skytracker.mapper.FlightAlertMapper;
+import com.skytracker.mapper.UserFlightAlertMapper;
 import com.skytracker.repository.FlightAlertRepository;
 import com.skytracker.repository.UserFlightAlertRepository;
 import com.skytracker.repository.UserRepository;
@@ -35,7 +37,7 @@ public class PriceAlertService {
         String uniqueKey = dto.buildUniqueKey();
 
         FlightAlert flightAlert = flightAlertRepository.findByUniqueKey(uniqueKey)
-                .orElseGet(() -> flightAlertRepository.save(FlightAlert.from(dto)));
+                .orElseGet(() -> flightAlertRepository.save(FlightAlertMapper.toEntity(dto)));
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 User 를 찾을 수 없습니다."));
@@ -61,7 +63,7 @@ public class PriceAlertService {
         String accessToken = amadeusTokenManger.getAmadeusAccessToken();
 
         flightAlertRepository.findAll().forEach(alert -> {
-            FlightAlertRequestDto requestDto = FlightAlertRequestDto.from(alert);
+            FlightAlertRequestDto requestDto = FlightAlertMapper.from(alert);
             int lastCheckedPrice = requestDto.getLastCheckedPrice();
             int newPrice = amadeusFlightSearchService.compareFlightsPrice(accessToken, requestDto);
 
@@ -94,7 +96,7 @@ public class PriceAlertService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         return userFlightAlertRepository.findAllByUser(user).stream()
-                .map(FlightAlertResponseDto::from)
+                .map(UserFlightAlertMapper::toDto)
                 .collect(Collectors.toList());
     }
 
@@ -106,5 +108,6 @@ public class PriceAlertService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 알림을 찾을 수 없습니다."));
 
         userFlightAlertRepository.delete(alert);
+        log.info("성공적으로 삭제되었습니다! {}", alertId);
     }
 }

--- a/apps/api-server/src/test/java/com/skytracker/service/PriceAlertServiceTest.java
+++ b/apps/api-server/src/test/java/com/skytracker/service/PriceAlertServiceTest.java
@@ -1,0 +1,127 @@
+package com.skytracker.service;
+
+import com.skytracker.common.dto.alerts.FlightAlertRequestDto;
+import com.skytracker.common.dto.alerts.FlightAlertResponseDto;
+import com.skytracker.entity.FlightAlert;
+import com.skytracker.entity.User;
+import com.skytracker.entity.UserFlightAlert;
+import com.skytracker.mapper.FlightAlertMapper;
+import com.skytracker.repository.FlightAlertRepository;
+import com.skytracker.repository.UserFlightAlertRepository;
+import com.skytracker.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PriceAlertServiceTest {
+
+    @Mock private FlightAlertRepository flightAlertRepository;
+    @Mock private UserFlightAlertRepository userFlightAlertRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private PriceAlertService priceAlertService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void register_ShouldSaveUserFlightAlert_WhenNotRegistered() {
+        Long userId = 1L;
+        FlightAlertRequestDto dto = FlightAlertRequestDto.builder()
+                .airlineCode("AA")
+                .flightNumber("123")
+                .departureAirport("ICN")
+                .arrivalAirport("JFK")
+                .departureDate("2025-08-01")
+                .currency("USD")
+                .adults(1)
+                .lastCheckedPrice(500)
+                .build();
+
+        FlightAlert alert = FlightAlertMapper.toEntity(dto);
+        User user = new User();
+
+        when(flightAlertRepository.findByUniqueKey(any())).thenReturn(Optional.empty());
+        when(flightAlertRepository.save(any())).thenReturn(alert);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userFlightAlertRepository.existsByUserAndFlightAlert(any(), any())).thenReturn(false);
+
+        assertDoesNotThrow(() -> priceAlertService.register(dto, userId));
+
+        verify(userFlightAlertRepository, times(1)).save(any(UserFlightAlert.class));
+    }
+
+    @Test
+    void deleteUserFlightAlert_ShouldDeleteEntity() {
+        User user = new User();
+        FlightAlert alert = new FlightAlert();
+        UserFlightAlert ufa = UserFlightAlert.builder().user(user).flightAlert(alert).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userFlightAlertRepository.findByUserAndFlightAlertId(user, 2L)).thenReturn(Optional.of(ufa));
+
+        priceAlertService.deleteUserFlightAlert(1L, 2L);
+
+        verify(userFlightAlertRepository, times(1)).delete(ufa);
+    }
+
+    @Test
+    void getUserFlightAlerts_ShouldReturnDtos() {
+        User user = new User();
+        FlightAlert alert = FlightAlert.builder()
+                .id(10L).departureAirport("ICN").arrivalAirport("JFK")
+                .adults(1).uniqueKey("STR").airlineCode("AA").flightNumber("AB").departureDate("12").arrivalDate("15").lastCheckedPrice(500).build();
+        UserFlightAlert ufa = UserFlightAlert.builder().user(user).flightAlert(alert).isActive(true).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userFlightAlertRepository.findAllByUser(user)).thenReturn(Collections.singletonList(ufa));
+
+        List<FlightAlertResponseDto> result = priceAlertService.getUserFlightAlerts(1L);
+
+        assertEquals(1, result.size());
+        assertEquals("ICN", result.get(0).getOrigin());
+    }
+
+    @Test
+    void register_ShouldThrowException_WhenDuplicateAlertExists() {
+        Long userId = 1L;
+        FlightAlertRequestDto dto = FlightAlertRequestDto.builder()
+                .airlineCode("AA")
+                .flightNumber("123")
+                .departureAirport("ICN")
+                .arrivalAirport("JFK")
+                .departureDate("2025-08-01")
+                .currency("USD")
+                .adults(1)
+                .lastCheckedPrice(500)
+                .build();
+
+        FlightAlert alert = FlightAlertMapper.toEntity(dto);
+        User user = new User();
+
+        when(flightAlertRepository.findByUniqueKey(any())).thenReturn(Optional.of(alert));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userFlightAlertRepository.existsByUserAndFlightAlert(user, alert)).thenReturn(true);
+
+        assertThrows(IllegalStateException.class, () -> priceAlertService.register(dto, userId));
+    }
+
+    @Test
+    void getUserFlightAlerts_ShouldThrowException_WhenUserNotFound() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> priceAlertService.getUserFlightAlerts(999L));
+    }
+}

--- a/apps/common/src/main/java/com/skytracker/common/dto/SearchLogDto.java
+++ b/apps/common/src/main/java/com/skytracker/common/dto/SearchLogDto.java
@@ -1,5 +1,6 @@
 package com.skytracker.common.dto;
 
+import com.skytracker.common.dto.flightSearch.FlightSearchRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/apps/common/src/main/java/com/skytracker/common/dto/alerts/FlightAlertRequestDto.java
+++ b/apps/common/src/main/java/com/skytracker/common/dto/alerts/FlightAlertRequestDto.java
@@ -23,7 +23,7 @@ public class FlightAlertRequestDto {
     private String currency;               // 통화 코드 (예: KRW)
     private int adults;                    // 성인 인원 수
     private int lastCheckedPrice;          // 마지막으로 확인된 가격
-    private int newPrice;                  // 최신 가격 (갱신 후 저장)
+    private Integer newPrice;              // 최신 가격 (갱신 후 저장)
 
 
     public String buildUniqueKey() {

--- a/apps/elasticsearch/src/main/java/skytracker/document/SearchLogsDocument.java
+++ b/apps/elasticsearch/src/main/java/skytracker/document/SearchLogsDocument.java
@@ -1,7 +1,5 @@
 package skytracker.document;
 
-import com.skytracker.dto.FlightSearchRequestDto;
-import com.skytracker.dto.SearchLogDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/apps/kafka-producer/src/main/java/com/skytracker/service/FlightSearchLogsProducer.java
+++ b/apps/kafka-producer/src/main/java/com/skytracker/service/FlightSearchLogsProducer.java
@@ -1,7 +1,6 @@
 package com.skytracker.service;
 
-import com.skytracker.dto.FlightSearchRequestDto;
-import com.skytracker.dto.SearchLogDto;
+import com.skytracker.common.dto.SearchLogDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;

--- a/apps/kafka-producer/src/main/java/com/skytracker/service/SearchLogService.java
+++ b/apps/kafka-producer/src/main/java/com/skytracker/service/SearchLogService.java
@@ -1,7 +1,7 @@
 package com.skytracker.service;
 
-import com.skytracker.dto.FlightSearchRequestDto;
-import com.skytracker.dto.SearchLogDto;
+import com.skytracker.common.dto.SearchLogDto;
+import com.skytracker.common.dto.flightSearch.FlightSearchRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
### 변경 내용 요약
- Entity ↔ DTO 간 직접 변환 제거 → Mapper 클래스 도입
- FlightAlertMapper, UserFlightAlertMapper 추가
- 단위 테스트 (PriceAlertServiceTest) 작성 및 성공

### 테스트 결과
- `./gradlew test` 성공
- DTO 매핑 및 기능 정상 작동 확인
