### PR TITLE
feat: RedisTemplate 공통 설정 분리 및 캐시 갱신 전략 개선

### DIFF
--- a/apps/api-server/build.gradle
+++ b/apps/api-server/build.gradle
@@ -25,10 +25,8 @@ repositories {
 
 dependencies {
 	implementation project(':apps:common')
-	implementation project(':apps:kafka-producer')
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/apps/api-server/src/main/java/com/skytracker/SkyTrackerApplication.java
+++ b/apps/api-server/src/main/java/com/skytracker/SkyTrackerApplication.java
@@ -1,6 +1,6 @@
 package com.skytracker;
 
-import com.skytracker.config.RedisClusterProperties;
+import com.skytracker.common.config.RedisClusterProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;

--- a/apps/api-server/src/main/java/com/skytracker/config/RedissonConfig.java
+++ b/apps/api-server/src/main/java/com/skytracker/config/RedissonConfig.java
@@ -1,5 +1,6 @@
 package com.skytracker.config;
 
+import com.skytracker.common.config.RedisClusterProperties;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;

--- a/apps/common/build.gradle
+++ b/apps/common/build.gradle
@@ -22,11 +22,21 @@ repositories {
 }
 
 dependencies {
+	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+	// Validation API
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+
+	// Redis 관련 추가
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.3'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:3.2.3'
+
+	// Test
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+
 }
 
 tasks.named('test') {

--- a/apps/common/src/main/java/com/skytracker/common/config/RedisClusterProperties.java
+++ b/apps/common/src/main/java/com/skytracker/common/config/RedisClusterProperties.java
@@ -1,4 +1,4 @@
-package com.skytracker.config;
+package com.skytracker.common.config;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/apps/common/src/main/java/com/skytracker/common/config/RedisConfig.java
+++ b/apps/common/src/main/java/com/skytracker/common/config/RedisConfig.java
@@ -1,7 +1,6 @@
-package com.skytracker.config;
+package com.skytracker.common.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;

--- a/apps/common/src/main/java/com/skytracker/common/dto/RouteAggregationDto.java
+++ b/apps/common/src/main/java/com/skytracker/common/dto/RouteAggregationDto.java
@@ -1,19 +1,19 @@
 package com.skytracker.common.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RouteAggregationDto {
-    private String routeCode;
-    private String departureDate;
-    private String returnDate;
-    private long count;
 
+    private String routeCode;        // ICN:NRT (출발 공항:도착 공항)
+    private String departureDate;    // 출발 날짜 (25-08-15)
+    private String returnDate;       // 도착 날짜 (25-08-20)
+    private long docCount;           // ES 집계 데이터
 
 }

--- a/apps/elasticsearch/build.gradle
+++ b/apps/elasticsearch/build.gradle
@@ -24,9 +24,10 @@ repositories {
 }
 
 dependencies {
-    implementation project(':apps:common')
+    implementation project(":apps:common")
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
 
@@ -46,7 +47,6 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation project(':apps:api-server')
 }
 
 tasks.named('test') {

--- a/apps/elasticsearch/src/main/java/skytracker/ElasticsearchApplication.java
+++ b/apps/elasticsearch/src/main/java/skytracker/ElasticsearchApplication.java
@@ -3,7 +3,7 @@ package skytracker;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.skytracker")
 public class ElasticsearchApplication {
 
     public static void main(String[] args) {

--- a/apps/elasticsearch/src/main/java/skytracker/dto/RouteAggregationDto.java
+++ b/apps/elasticsearch/src/main/java/skytracker/dto/RouteAggregationDto.java
@@ -1,0 +1,20 @@
+package skytracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteAggregationDto
+{
+    private String departureAirportCode;  //출발 항공 (ICN)
+    private String arrivalAirport;        //도착 항공 (NRT)
+    private String departureDate;         // 25-08-10
+    private String arrivalDate;           // 25-08-15 or Null
+    private long docCount;                // ES에서 수집된 항공권 수
+
+}

--- a/apps/elasticsearch/src/main/java/skytracker/service/RouteAggregationScheduler.java
+++ b/apps/elasticsearch/src/main/java/skytracker/service/RouteAggregationScheduler.java
@@ -1,21 +1,48 @@
 package skytracker.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skytracker.common.dto.RouteAggregationDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RouteAggregationScheduler {
 
     private final ElasticAggregationService esAggregationService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String HOT_KEY = "HOT_ROUTES";
+    private static final String TEMP_KEY = "HOT_ROUTES:TMP";
+
 
     @Scheduled(cron = "0 0 1 * * *")
     public void updateHotRoutes() throws IOException {
-        List<RouteAggregationDto> topRoutes = esAggregationService.getTopRoute(10);
-    }
+        try {
+            List<RouteAggregationDto> topRoutes = esAggregationService.getTopRoute(10);
+            topRoutes.sort((a, b) -> Long.compare(b.getDocCount(), a.getDocCount()));
+
+            redisTemplate.delete(TEMP_KEY);
+
+            for (RouteAggregationDto route : topRoutes) {
+                String json = objectMapper.writeValueAsString(route);
+                redisTemplate.opsForList().rightPush(TEMP_KEY, json);
+            }
+
+            redisTemplate.rename(TEMP_KEY, HOT_KEY);
+
+
+        } catch (Exception e) {
+            log.error("인기 노선 캐싱 실패", e);
+        }
+        }
+
 }

--- a/apps/elasticsearch/src/main/resources/application.yml
+++ b/apps/elasticsearch/src/main/resources/application.yml
@@ -32,8 +32,14 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      cluster:
+        nodes:
+          - redis-node-1:6379
+          - redis-node-2:6379
+          - redis-node-3:6379
+          - redis-node-4:6379
+          - redis-node-5:6379
+          - redis-node-6:6379
 
   amadeus:
     api:

--- a/apps/kafka-producer/build.gradle
+++ b/apps/kafka-producer/build.gradle
@@ -37,7 +37,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation project(':apps:api-server')
 }
 
 tasks.named('test') {

--- a/apps/kafka-producer/src/main/java/com/skytracker/service/SearchLogService.java
+++ b/apps/kafka-producer/src/main/java/com/skytracker/service/SearchLogService.java
@@ -17,7 +17,7 @@ public class SearchLogService {
         try {
             SearchLogDto searchLogDto = SearchLogDto.from(req);
             searchLogsProducer.sendSearchLogs(searchLogDto);// Kafka 발행
-            log.info("search logs publish succeed: {} → {}", req.getOriginLocationCode(), req.getDestinationLocationCode());
+            log.info("search logs publish succeed: {} → {}", req.getOriginLocationAirport(), req.getDestinationLocationAirPort());
         } catch (Exception e) {
             log.error("search logs published failed", e);
         }


### PR DESCRIPTION
- RedisTemplate 설정을 common 모듈로 이동하여 여러 모듈에서 공유 가능하도록 구성
- Redis 의존성과 yml 설정을 통합하여 일관성 확보
- TTL 대신 매일 초기화 + 갱신 전략 도입
- 안정성 확보를 위해 delete 대신 rename 방식 적용
- build.gradle 내 모듈 간 순환 의존성 문제 제거 및 구조 개선